### PR TITLE
Add ytlargeGPT FastAPI backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# Api-key
+# ytlargeGPT
+
+Backend service to analyze YouTube videos and return basic metadata and a
+simulated monetization flag.
+
+## Running locally
+
+```bash
+pip install -r requirements.txt
+python main.py
+```
+
+POST a JSON payload containing a `url` field to `/analyze`.
+
+Additional endpoints:
+
+- `GET /` simple health check.
+- `POST /ytlarge-info` accepts a JSON body with `url` and returns simulated video insights.
+
+OpenAPI specification is available in `openapi.yaml`.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,158 @@
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+import httpx
+from urllib.parse import urlparse, parse_qs
+from typing import List
+
+YOUTUBE_API_KEY = "AIzaSyD9-pgZDBpYk0Mz3j8MdERoaATq5fSg1tE"
+
+app = FastAPI(title="ytlargeGPT")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+class AnalyzeRequest(BaseModel):
+    url: str
+
+class AnalyzeResponse(BaseModel):
+    title: str
+    channelId: str
+    channelTitle: str
+    views: int
+    uploadDate: str
+    category: str
+    tags: List[str]
+    monetized: bool
+
+
+class URLRequest(BaseModel):
+    url: str
+
+
+class Metadata(BaseModel):
+    title: str
+    uploadDate: str
+    category: str
+    views: int
+
+
+class InfoResponse(BaseModel):
+    monetized: bool
+    authenticity: str
+    estimatedEarnings: str
+    tags: List[str]
+    metadata: Metadata
+
+def extract_video_id(url: str) -> str:
+    parsed = urlparse(url)
+    if parsed.hostname in ("youtu.be", "www.youtu.be"):
+        return parsed.path.lstrip("/")
+    if parsed.hostname in ("www.youtube.com", "youtube.com"):
+        if parsed.path == "/watch":
+            qs = parse_qs(parsed.query)
+            return qs.get("v", [""])[0]
+        if parsed.path.startswith("/embed/"):
+            return parsed.path.split("/")[2]
+    raise ValueError("Invalid YouTube URL")
+
+
+@app.get("/")
+async def health() -> dict:
+    return {"status": "YTLarge GPT API is live!"}
+
+
+@app.post("/ytlarge-info", response_model=InfoResponse)
+async def ytlarge_info(req: URLRequest) -> InfoResponse:
+    _ = req.url
+    return InfoResponse(
+        monetized=True,
+        authenticity="high",
+        estimatedEarnings="$123 - $456",
+        tags=["AI", "YouTube", "Growth"],
+        metadata=Metadata(
+            title="Sample Video Title",
+            uploadDate="2023-12-01",
+            category="Education",
+            views=120000,
+        ),
+    )
+
+@app.post("/analyze", response_model=AnalyzeResponse)
+async def analyze(req: AnalyzeRequest):
+    try:
+        video_id = extract_video_id(req.url)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    async with httpx.AsyncClient() as client:
+        video_resp = await client.get(
+            "https://www.googleapis.com/youtube/v3/videos",
+            params={
+                "part": "snippet,statistics,status",
+                "id": video_id,
+                "key": YOUTUBE_API_KEY,
+            },
+        )
+        video_data = video_resp.json()
+        items = video_data.get("items", [])
+        if not items:
+            raise HTTPException(status_code=404, detail="Video not found")
+        video = items[0]
+        snippet = video.get("snippet", {})
+        statistics = video.get("statistics", {})
+        status = video.get("status", {})
+        channel_id = snippet.get("channelId")
+
+        # Fetch channel status
+        channel_resp = await client.get(
+            "https://www.googleapis.com/youtube/v3/channels",
+            params={
+                "part": "status",
+                "id": channel_id,
+                "key": YOUTUBE_API_KEY,
+            },
+        )
+        channel_items = channel_resp.json().get("items", [])
+        channel_status = channel_items[0]["status"] if channel_items else {}
+
+        # Fetch category title
+        category_resp = await client.get(
+            "https://www.googleapis.com/youtube/v3/videoCategories",
+            params={
+                "part": "snippet",
+                "id": snippet.get("categoryId"),
+                "key": YOUTUBE_API_KEY,
+            },
+        )
+        category_items = category_resp.json().get("items", [])
+        category = (
+            category_items[0]["snippet"].get("title") if category_items else "Unknown"
+        )
+
+        monetized = bool(
+            status.get("embeddable")
+            and status.get("license") == "youtube"
+            and channel_status.get("isLinked")
+        )
+
+        return AnalyzeResponse(
+            title=snippet.get("title", ""),
+            channelId=channel_id or "",
+            channelTitle=snippet.get("channelTitle", ""),
+            views=int(statistics.get("viewCount", 0)),
+            uploadDate=snippet.get("publishedAt", "").split("T")[0],
+            category=category,
+            tags=snippet.get("tags", []),
+            monetized=monetized,
+        )
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,109 @@
+openapi: 3.0.1
+info:
+  title: ytlargeGPT
+  version: '1.0.0'
+paths:
+  /:
+    get:
+      summary: Service health check
+      responses:
+        '200':
+          description: API status message
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: YTLarge GPT API is live!
+  /ytlarge-info:
+    post:
+      summary: Return simulated video insights
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                url:
+                  type: string
+                  description: YouTube video URL
+      responses:
+        '200':
+          description: Simulated YouTube data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  monetized:
+                    type: boolean
+                  authenticity:
+                    type: string
+                  estimatedEarnings:
+                    type: string
+                  tags:
+                    type: array
+                    items:
+                      type: string
+                  metadata:
+                    type: object
+                    properties:
+                      title:
+                        type: string
+                      uploadDate:
+                        type: string
+                        format: date
+                      category:
+                        type: string
+                      views:
+                        type: integer
+  /analyze:
+    post:
+      summary: Analyze a YouTube video
+      description: >-
+        Accepts a YouTube video URL and returns metadata and a simulated
+        monetization flag.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                url:
+                  type: string
+                  description: Full YouTube video URL
+                  example: https://www.youtube.com/watch?v=dQw4w9WgXcQ
+      responses:
+        '200':
+          description: Video analysis results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  title:
+                    type: string
+                  channelId:
+                    type: string
+                  channelTitle:
+                    type: string
+                  views:
+                    type: integer
+                  uploadDate:
+                    type: string
+                    format: date
+                  category:
+                    type: string
+                  tags:
+                    type: array
+                    items:
+                      type: string
+                  monetized:
+                    type: boolean
+servers:
+  - url: http://localhost:8000
+    description: Local development server

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+httpx


### PR DESCRIPTION
## Summary
- implement health endpoint returning API status
- add /ytlarge-info endpoint with simulated earnings and metadata
- expand OpenAPI spec and README with new endpoints

## Testing
- `pip install fastapi uvicorn httpx` *(failed: Could not find a version that satisfies the requirement fastapi)*
- `python -m py_compile main.py`
- `python main.py` *(failed: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688eb7f5e1f4832185aef8078eda673e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a health check endpoint to confirm API availability.
  * Introduced a new endpoint that returns simulated video insights, including monetization status, authenticity, estimated earnings, tags, and detailed metadata.

* **Documentation**
  * Updated documentation to describe all available endpoints and their responses, including the new health check and video insights endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->